### PR TITLE
Fix target directory naming

### DIFF
--- a/issue2mbox
+++ b/issue2mbox
@@ -111,12 +111,12 @@ def main():
         log.fatal("Cant login: %s", errmsg)
         sys.exit(1)
 
+    repo_name = args.repo
     try:
-        repo = args.repo
-        match = re.match(r"^(?:https://github.com/)?\w+/(.+)$", repo)
+        match = re.match(r"^(?:https://github.com/)?\w+/(.+)$", repo_name)
         if match:
-            repo = match.group(1)
-        repo = user.get_repo(repo)
+            repo_name = match.group(1)
+        repo = user.get_repo(repo_name)
     except GithubException as errmsg:
         log.fatal("Cant locate repository: %s", errmsg)
         sys.exit(1)
@@ -124,7 +124,7 @@ def main():
     if args.dest:
         target = args.dest
     else:
-        target = f"/tmp/{repo}"
+        target = f"/tmp/{repo_name}"
 
     issues = repo.get_issues(state="all")
 


### PR DESCRIPTION
Sorry about this, but the last patch has an issue where the target directory could result in a bogus name.

Also, would it make sense to use the current working directory, instead of /tmp?